### PR TITLE
We need to link against -ltinfo too

### DIFF
--- a/src/kc/Makefile.am
+++ b/src/kc/Makefile.am
@@ -198,4 +198,4 @@ kcemu_send_SOURCES = \
 	kcemu-send.c
 
 kcemu_send_LDADD = \
-	-lncurses $(INTLLIBS)
+	-lncurses -ltinfo $(INTLLIBS)

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -44,7 +44,7 @@ AM_CPPFLAGS = \
 #disp_wav_SOURCES = \
 #	disp-wav.c
 #disp_wav_LDADD = \
-#	-lncurses
+#	-lncurses -ltinfo
 
 disk_tool_SOURCES = \
 	disk-tool.c


### PR DESCRIPTION
It should be more future-proof to rely on pkg-config.